### PR TITLE
Adding a progressDeadlineSeconds to the deployment file

### DIFF
--- a/deployment/kubernetes/deployment.template.yml
+++ b/deployment/kubernetes/deployment.template.yml
@@ -1,15 +1,19 @@
-apiVersion: extensions/v1beta1 
+apiVersion: apps/v1
 kind: Deployment 
 metadata: 
   name: crds-auth
   namespace: api
 spec: 
   replicas: 2
+  progressDeadlineSeconds: 180
   strategy: 
     type: RollingUpdate 
     rollingUpdate: 
       maxSurge: 2
       maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: crds-auth
   template: 
     metadata: 
       labels:


### PR DESCRIPTION
Check associated story for more details. This PR allows us to fail a deployment if it has not progressed in the specified amount of seconds. This would be the case where containers fail to start. This gets us feedback on deployment in TeamCity.