### PR TITLE
[CYP] Fixed kickoff test command

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -24,4 +24,4 @@ services:
       - CYPRESS_VAULT_SECRET_ID=${VAULT_SECRET_ID}
       - CYPRESS_CRDS_ENV=${CRDS_ENV}
     working_dir: /cypress-service-auth
-    command: /cypress-service-auth/wait-for-it.sh auth:80 -- npx cypress run
+    entrypoint: /cypress-service-auth/wait-for-it.sh auth:80 -- npx cypress run


### PR DESCRIPTION
- The cypress/include image predefines an entrypoint that we don't want to use. This should fix it.